### PR TITLE
docs: add usage and API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # esse-rails
  Ruby on Rails extensions for [esse](https://github.com/marcosgz/esse) elasticsearch/opensearch client
 
+## Documentation
+
+Full guides, Railtie reference, and generator docs are published at **[gems.marcosz.com.br/esse-rails](https://gems.marcosz.com.br/esse-rails/)** — part of the [marcosgz Ruby gem catalogue](https://gems.marcosz.com.br).
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# esse-rails
+
+Rails integration for [Esse](../../esse/docs/README.md). Adds:
+
+- Controller-level instrumentation: "Search: X.Xms" appears alongside "Views" in your logs.
+- Lograge integration: a `search` key in your JSON logs.
+- Automatic Rails environment loading when the `esse` CLI runs in a Rails app.
+
+## Contents
+
+- [Usage guide](usage.md)
+- [API reference](api.md)
+
+## What you see
+
+Without any code changes you get:
+
+```
+Processing UsersController#index as HTML
+  ...
+Completed 200 OK in 125.3ms (Views: 45.2ms | Search: 78.1ms)
+```
+
+With Lograge enabled:
+
+```
+method=GET path=/search status=200 duration=380.89 view=99.64 db=0.00 search=279.37
+```
+
+## Install
+
+```ruby
+# Gemfile
+gem 'esse'
+gem 'esse-rails'
+```
+
+That's it. No initializer or DSL is required for controller instrumentation. For Lograge, add a single require (see [Usage](usage.md)).
+
+## Version
+
+- Version: **0.0.4**
+- Ruby: `>= 2.5.0`
+- Depends on: `esse >= 0.2.2`, `activesupport >= 4.2`
+
+## License
+
+MIT.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,87 @@
+# API Reference
+
+The gem wires everything up at load time. Its public surface is mostly under-the-hood machinery.
+
+## `Esse::Rails::Instrumentation::ControllerRuntime`
+
+A concern mixed into `ActionController::Base` (and the API subclass) via `ActiveSupport.on_load(:action_controller)`.
+
+### Instance methods
+
+| Method | Description |
+|--------|-------------|
+| `process_action(action, *args)` | Resets the runtime registry before each action. |
+| `cleanup_view_runtime` | Captures the runtime spent during view rendering. |
+| `append_info_to_payload(payload)` | Adds `:esse_runtime` to the action payload. |
+
+### Attribute
+
+- `esse_runtime` (attr_internal) — total search runtime in seconds for the request.
+
+The payload key name is `:esse_runtime`. Rails' log subscriber picks it up and prints `Search: X.Xms` alongside `Views:` in the log line.
+
+---
+
+## `Esse::Rails::Instrumentation::RuntimeRegistry`
+
+Thread-local runtime accumulator.
+
+| Method | Description |
+|--------|-------------|
+| `.runtime` | Current cumulative runtime (Float seconds). Defaults to 0. |
+| `.runtime = value` | Set the current cumulative runtime. |
+| `.reset` | Returns the current value and resets to 0. |
+
+Stored on `Thread.current`, one slot per thread.
+
+---
+
+## `Esse::Rails::CLI::Autoloader`
+
+Prepended into `Esse::CLI::Root`. Hooks into the `after_initialize` phase of the CLI to require `config/environment.rb` if present.
+
+You don't interact with this directly. It just means CLI commands can reference your Rails models without extra setup.
+
+---
+
+## Lograge Railtie
+
+Loaded with:
+
+```ruby
+require 'esse/rails/lograge'
+```
+
+### Behavior
+
+- Registers a `config.lograge.custom_options` lambda.
+- The lambda extracts `:esse_runtime` from the event payload and adds `search: <ms>` to the Lograge output.
+- Multiplier: runtime is converted from seconds (internal) to milliseconds (output).
+
+### Customizing further
+
+If you already use `custom_options`, the library's lambda is merged in. To stack options, wrap it yourself:
+
+```ruby
+Rails.application.config.lograge.custom_options = lambda do |event|
+  existing = { esse_runtime_ms: ((event.payload[:esse_runtime] || 0) * 1000).round(2) }
+  existing.merge(my_stuff(event))
+end
+```
+
+---
+
+## Event subscriptions
+
+On boot the gem does roughly:
+
+```ruby
+Esse::Events.event_names.grep(/^elasticsearch/).each do |name|
+  Esse::Events.subscribe(name) do |event|
+    runtime = event.payload[:runtime] || 0
+    Esse::Rails::Instrumentation::RuntimeRegistry.runtime += runtime
+  end
+end
+```
+
+So every ES/OS operation is tracked automatically, no per-controller configuration required.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,86 @@
+# Usage Guide
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'esse'
+gem 'esse-rails'
+```
+
+No initializer or configuration is required. On boot the gem:
+
+- Subscribes to every `elasticsearch.*` event published by Esse.
+- Adds a thread-local runtime accumulator.
+- Includes `ControllerRuntime` into `ActionController::Base` (and API subclass) via `ActiveSupport.on_load`.
+- Prepends a CLI autoloader that loads `config/environment.rb` before commands execute.
+
+## Default instrumentation
+
+Every controller action logs the aggregate ES/OS runtime:
+
+```
+Completed 200 OK in 125.3ms (Views: 45.2ms | Search: 78.1ms)
+```
+
+The runtime is reset at the start of each action, accumulated across all `elasticsearch.*` events during request processing, and appended to the action's payload.
+
+## Lograge integration
+
+If you use [Lograge](https://github.com/roidrage/lograge), require the adapter in your app initializer:
+
+```ruby
+# config/application.rb
+require 'esse/rails/lograge'
+
+config.lograge.enabled = true
+config.lograge.formatter = Lograge::Formatters::Json.new
+```
+
+You now get a `search` key (in milliseconds) in every Lograge entry:
+
+```
+{"method":"GET","path":"/search","status":200,"duration":380.89,"view":99.64,"db":0.0,"search":279.37}
+```
+
+No other changes are needed — the Railtie registers a `custom_options` lambda for you.
+
+## CLI integration
+
+Run `esse` commands inside a Rails app and the environment is loaded automatically:
+
+```bash
+bundle exec esse index reset UsersIndex
+bundle exec esse index import UsersIndex
+```
+
+The autoloader loads `config/environment.rb` before executing the command, giving you access to:
+
+- Models, constants, and the rest of your Rails autoload paths.
+- Your `config/esse.rb` or `config/initializers/esse.rb` initializer.
+- Rails-dependent plugins (like `esse-active_record`).
+
+## What events are tracked?
+
+The gem subscribes to every event matching `/^elasticsearch/`, which includes:
+
+- `elasticsearch.search`, `elasticsearch.execute_search_query`
+- `elasticsearch.bulk`, `elasticsearch.index`, `elasticsearch.update`, `elasticsearch.delete`
+- `elasticsearch.get`, `elasticsearch.mget`, `elasticsearch.count`, `elasticsearch.exist`
+- `elasticsearch.create_index`, `elasticsearch.delete_index`, `elasticsearch.refresh`
+- And others — see [Events](../../esse/docs/events.md).
+
+The runtime of each event is added to `RuntimeRegistry.runtime`. The registry is reset per-action, so the number shown is the sum of time spent in ES/OS during that controller action.
+
+## Thread safety
+
+`RuntimeRegistry` uses `Thread.current`, so each request has an independent view. This matches the pattern that `ActiveRecord::LogSubscriber` uses for `db=` timings.
+
+## Turning it off
+
+You can't turn off the event subscribers from the outside, but you can:
+
+- Subclass `ActionController::Base` with a custom parent and skip including `ControllerRuntime`.
+- Log at a different level (Rails' request logging already respects `config.log_level`).
+
+In practice, the instrumentation is low-cost — a hash lookup per event.


### PR DESCRIPTION
## Summary

Adds `docs/` with three files:

- `README.md` — overview and entry point
- `usage.md` — Rails setup: Railtie, autoload paths, config, and generators
- `api.md` — reference for the Railtie and exposed configuration

## Test plan

- [ ] Skim `docs/README.md` as a navigation entry point
- [ ] Verify installation and config examples match the current API
- [ ] Verify `api.md` references match the gem's constants